### PR TITLE
add subtype check for mov matcher

### DIFF
--- a/matchers/video.go
+++ b/matchers/video.go
@@ -53,8 +53,9 @@ func Webm(buf []byte) bool {
 func Mov(buf []byte) bool {
 	return len(buf) > 15 && ((buf[0] == 0x0 && buf[1] == 0x0 &&
 		buf[2] == 0x0 && (buf[3] == 0x14 || buf[3] == 0x20) &&
-		buf[4] == 0x66 && buf[5] == 0x74 &&
-		buf[6] == 0x79 && buf[7] == 0x70) ||
+		buf[4] == 0x66 && buf[5] == 0x74 && // 'f' 't'
+		buf[6] == 0x79 && buf[7] == 0x70 && // 'y' 'p'
+		buf[8] == 0x71 && buf[9] == 0x74) || // 'q' 't'
 		(buf[4] == 0x6d && buf[5] == 0x6f && buf[6] == 0x6f && buf[7] == 0x76) ||
 		(buf[4] == 0x6d && buf[5] == 0x64 && buf[6] == 0x61 && buf[7] == 0x74) ||
 		(buf[12] == 0x6d && buf[13] == 0x64 && buf[14] == 0x61 && buf[15] == 0x74))


### PR DESCRIPTION
one mp4 video has below header, and match both mov and mp4 type based on current video matcher because of a map structure. Return result becomes unpredictable. This commit is to explicitly check subtype for mov file to exclude mov file for this type of videos

```
00000000: 0000 0020 6674 7970 6973 6f6d 0000 0200  ... ftypisom....
00000010: 6973 6f6d 6973 6f32 6176 6331 6d70 3431  isomiso2avc1mp41
```

From Apple
https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-CJBCBIFF which describes subtype `qt` is needed for mov file
```
The file type atom has an atom type value of 'ftyp' and contains the
following fields:
Size
A 32-bit unsigned integer that specifies the number of bytes in this
atom.
Type
A 32-bit unsigned integer that identifies the atom type, typically
represented as a four-character code; this field must be set to 'ftyp'.
Major_Brand
A 32-bit unsigned integer that should be set to 'qt ' (note the two
trailing ASCII space characters) for QuickTime movie files.
```

Signed-off-by: Leslie <wqyuwss@gmail.com>